### PR TITLE
Use post update with sensor plugins

### DIFF
--- a/src/gazebo_barometer_plugin.cpp
+++ b/src/gazebo_barometer_plugin.cpp
@@ -85,6 +85,10 @@ void BarometerPlugin::Configure(const ignition::gazebo::Entity &_entity,
 
 void BarometerPlugin::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
   ignition::gazebo::EntityComponentManager &_ecm) {
+}
+
+void BarometerPlugin::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
+    const ignition::gazebo::EntityComponentManager &_ecm) {
     const std::chrono::steady_clock::duration current_time = _info.simTime;
     const double dt = std::chrono::duration<double>(current_time - last_pub_time_).count();
   if (dt > 1.0 / pub_rate_) {
@@ -157,8 +161,4 @@ void BarometerPlugin::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
     // Publish baro msg
     pub_baro_.Publish(baro_msg_);
   }
-}
-
-void BarometerPlugin::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
-    const ignition::gazebo::EntityComponentManager &_ecm) {
 }

--- a/src/gazebo_gps_plugin.cpp
+++ b/src/gazebo_gps_plugin.cpp
@@ -154,6 +154,10 @@ void GpsPlugin::Configure(const ignition::gazebo::Entity &_entity,
 
 void GpsPlugin::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
   ignition::gazebo::EntityComponentManager &_ecm) {
+}
+
+void GpsPlugin::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
+    const ignition::gazebo::EntityComponentManager &_ecm) {
   const std::chrono::steady_clock::duration current_time = _info.simTime;
   const double dt = std::chrono::duration<double>(current_time - last_pub_time_).count();
   if (dt > 1.0 / update_rate_) {
@@ -234,8 +238,4 @@ void GpsPlugin::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
     pub_gps_.Publish(gps_msg);
     last_pub_time_ = current_time;
   }
-}
-
-void GpsPlugin::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
-    const ignition::gazebo::EntityComponentManager &_ecm) {
 }

--- a/src/gazebo_magnetometer_plugin.cpp
+++ b/src/gazebo_magnetometer_plugin.cpp
@@ -169,6 +169,10 @@ void MagnetometerPlugin::addNoise(Eigen::Vector3d* magnetic_field, const double 
 
 void MagnetometerPlugin::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
   ignition::gazebo::EntityComponentManager &_ecm) {
+}
+
+void MagnetometerPlugin::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
+    const ignition::gazebo::EntityComponentManager &_ecm) {
   const std::chrono::steady_clock::duration current_time = _info.simTime;
   const double dt = std::chrono::duration<double>(current_time - last_pub_time_).count();
   if (dt > 1.0 / pub_rate_) {
@@ -216,8 +220,4 @@ void MagnetometerPlugin::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
     // publish mag msg
     pub_mag_.Publish(mag_message_);
   }
-}
-
-void MagnetometerPlugin::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
-    const ignition::gazebo::EntityComponentManager &_ecm) {
 }


### PR DESCRIPTION
**Problem Description**
Sensor updates such as the GPS were integrated in the PreUpdate phase.

However, according to the documentation in https://ignitionrobotics.org/api/gazebo/2.10/createsystemplugins.html, sensor data should be read from the post update phase.

This PR moves the sensor message publication from PreUpdate to PostUpdate For the following sensors
- Barometer
- GPS
- Magnetometer