### PR TITLE
Fix github actions build test

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2.3.1
       with:
         repository: PX4/Firmware
-        ref: master
+        ref: main
         path: Firmware
         fetch-depth: 0
         submodules: recurvise


### PR DESCRIPTION
**Problem Description**
The `master` branch no longer exists in the Firmware repository, and therefore github actions started failing

**Solution**
This PR fixes the problem by changing the firmware branch to be used to `main`